### PR TITLE
Ensure expired tokens are rejected. Default JwtValidationClockSkew of…

### DIFF
--- a/BlazorWebAssemblyOidc/Server/Startup.cs
+++ b/BlazorWebAssemblyOidc/Server/Startup.cs
@@ -8,6 +8,7 @@ using BlazorWebAssemblyOidc.Shared.Services;
 using BlazorWebAssemblyOidc.Shared.Repositories;
 using IdentityServer4.AccessTokenValidation;
 using Microsoft.OpenApi.Models;
+using System;
 
 namespace BlazorWebAssemblyOidc.Server
 {
@@ -40,6 +41,7 @@ namespace BlazorWebAssemblyOidc.Server
                     options.Authority = "https://demo.identityserver.io/";
                     options.RequireHttpsMetadata = true;
                     options.ApiName = "api";
+                    options.JwtValidationClockSkew = TimeSpan.Zero;
                 });
 
             services.AddTransient<IWeatherForecastService, WeatherForecastService>();


### PR DESCRIPTION
… 5 minutes should normally be ok, but for testing purposes this is tightened to zero.